### PR TITLE
Only use path, when it's available

### DIFF
--- a/lib/CacheWrapper.php
+++ b/lib/CacheWrapper.php
@@ -57,10 +57,12 @@ class CacheWrapper extends Wrapper  {
 	const PERMISSION_DELETE = 8;
 
 	protected function formatCacheEntry($entry) {
-		try {
-			$this->operation->checkFileAccess($this->storage, $entry['path']);
-		} catch (ForbiddenException $e) {
-			$entry['permissions'] &= $this->mask;
+		if (isset($entry['path']) && isset($entry['permissions'])) {
+			try {
+				$this->operation->checkFileAccess($this->storage, $entry['path']);
+			} catch (ForbiddenException $e) {
+				$entry['permissions'] &= $this->mask;
+			}
 		}
 		return $entry;
 	}


### PR DESCRIPTION
Version app does a request where the entry only is: `$entry = ['encrypted' => false];`
So we ignore this case now.

Fix #39 

@LukasReschke @schiessle 