### PR TITLE
Do not set retry flag on ForbiddenException

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -82,7 +82,7 @@ class Operation implements IComplexOperation, ISpecificOperation {
 
 		if (!empty($match)) {
 			// All Checks of one operation matched: prevent access
-			throw new ForbiddenException('Access denied', true);
+			throw new ForbiddenException('Access denied', false);
 		}
 	}
 


### PR DESCRIPTION
For https://github.com/nextcloud/server/pull/22556

From https://github.com/owncloud/core/pull/20494 i assumed that the retry was introduced to indicate that clients should try to sync again at a later point, so I think it makes sense to not set this for files_accesscontrol thrown ForbiddenExceptions.