### PR TITLE
Fix path in shared storages

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -102,7 +102,7 @@ class Operation implements IComplexOperation, ISpecificOperation {
 
 			if ($hasMountPoint) {
 				/** @var StorageWrapper $storage */
-				$fullPath = $storage->mountPoint . $path;
+				$fullPath = $storage->mountPoint . ltrim($path, '/');
 			} else {
 				$fullPath = $path;
 			}


### PR DESCRIPTION
Not sure when this started, but In Nextcloud 20 the path still has no leading slash, but in 17-19 it has.
The problem is the mountpoint always has a trailing slash, so currently the path is:
`/admin//files/SharedFolder/test.txt`, so the "app" is `''` and we don't accesscontrol for that app, just files, thumbnails (legacy reason) and versions