### PR TITLE
don't apply access control wrapper on the root mount

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -55,7 +55,7 @@ class Application extends App implements IBootstrap {
 	 * @return StorageWrapper|IStorage
 	 */
 	public function addStorageWrapperCallback($mountPoint, IStorage $storage) {
-		if (!OC::$CLI && !$storage->instanceOfStorage(SharedStorage::class)) {
+		if (!OC::$CLI && !$storage->instanceOfStorage(SharedStorage::class) && $mountPoint !== '/') {
 			/** @var Operation $operation */
 			$operation = $this->getContainer()->get(Operation::class);
 			return new StorageWrapper([


### PR DESCRIPTION
Having the storage wrapper applied on the mountpoint leads to issues with rules being applied to groupfolders incorrectly as the access control wrapper will be applied both "inside" the groupfolder jail and "outside".

The access control wrapper "inside" the jail will lead to it checking rules for the path "__groupfolders/1/foo/bar" on the groupfolder storage, which leads to it not being able to load the proper tags.
The wrapper "outside" will use the correct path "foo/bar" and is able to get the proper tags.

This isn't an issue if a tag is used to block access, since if just the "outside" one blocks the behavior is as expected, however is access is granted based on a tag, if one of the two wrappers doesn't load the correct tag the access will be blocked incorrectly.

Longs story short, making the access control wrapper only apply "outside" stops rules being matched incorrectly.