### PR TITLE
don't exclude shared storage from wrapper

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -55,7 +55,7 @@ class Application extends App implements IBootstrap {
 	 * @return StorageWrapper|IStorage
 	 */
 	public function addStorageWrapperCallback($mountPoint, IStorage $storage) {
-		if (!OC::$CLI && !$storage->instanceOfStorage(SharedStorage::class) && $mountPoint !== '/') {
+		if (!OC::$CLI && $mountPoint !== '/') {
 			/** @var Operation $operation */
 			$operation = $this->getContainer()->get(Operation::class);
 			return new StorageWrapper([

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -23,7 +23,6 @@ namespace OCA\FilesAccessControl\AppInfo;
 
 use OC;
 use OC\Files\Filesystem;
-use OCA\Files_Sharing\SharedStorage;
 use OCA\FilesAccessControl\Listener\FlowRegisterOperationListener;
 use OCA\FilesAccessControl\Operation;
 use OCA\FilesAccessControl\StorageWrapper;


### PR DESCRIPTION
ensures rules are applied consistently