### PR TITLE
do not run file access check while source storage is not initialized

### DIFF
--- a/lib/CacheWrapper.php
+++ b/lib/CacheWrapper.php
@@ -55,7 +55,7 @@ class CacheWrapper extends Wrapper {
 	public const PERMISSION_DELETE = 8;
 
 	protected function formatCacheEntry($entry) {
-		if (isset($entry['path']) && isset($entry['permissions'])) {
+		if (isset($entry['path']) && isset($entry['permissions']) && $this->storage->getWrapperStorage() !== null) {
 			try {
 				$this->operation->checkFileAccess($this->storage, $entry['path'], $entry['mimetype'] === 'httpd/unix-directory');
 			} catch (ForbiddenException $e) {


### PR DESCRIPTION
there is a case with non-local storage, that under specific circumstances formatCacheEntry() is called while the source storage is still being set up: when the scanner finds a new file, and the autotagging tags it. Needs testing, and it should be ensured that no loophole is opened.