### PR TITLE
return of `current()` may be false

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -282,6 +282,9 @@ class Operation implements IComplexOperation, ISpecificOperation {
 
 	private function getNode(IStorage $storage, string $path): ?Node {
 		$mountPoint = current($this->mountManager->findByStorageId($storage->getId()));
+		if ($mountPoint === false) {
+			return null;
+		}
 		$fullPath = $mountPoint->getMountPoint() . $path;
 		try {
 			return $this->rootFolder->get($fullPath);


### PR DESCRIPTION
Fixes a potential `Call to a member function getMountPoint() on bool` on e.g. move.  