### PR TITLE
reuse the cache entry we already have when doing rule checking

### DIFF
--- a/lib/CacheWrapper.php
+++ b/lib/CacheWrapper.php
@@ -57,7 +57,7 @@ class CacheWrapper extends Wrapper {
 	protected function formatCacheEntry($entry) {
 		if (isset($entry['path']) && isset($entry['permissions'])) {
 			try {
-				$this->operation->checkFileAccess($this->storage, $entry['path'], $entry['mimetype'] === 'httpd/unix-directory');
+				$this->operation->checkFileAccess($this->storage, $entry['path'], $entry['mimetype'] === 'httpd/unix-directory', $entry);
 			} catch (ForbiddenException $e) {
 				$entry['permissions'] &= $this->mask;
 			}

--- a/lib/StorageWrapper.php
+++ b/lib/StorageWrapper.php
@@ -30,7 +30,6 @@ use OCP\Files\Storage\IStorage;
 use OCP\Files\Storage\IWriteStreamStorage;
 
 class StorageWrapper extends Wrapper implements IWriteStreamStorage {
-
 	/** @var Operation */
 	protected $operation;
 


### PR DESCRIPTION
Instead of having to re-quest the filecache for every item we have to check.

Fixes performance regression from https://github.com/nextcloud/files_accesscontrol/pull/293