### PR TITLE
[stable28] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -183,12 +183,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "80cdd62e56c7bf54d35ea2f012786e6cf7d4de27"
+                "reference": "8c3209a00e424f1ddcdfff15cb80081373210681"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/80cdd62e56c7bf54d35ea2f012786e6cf7d4de27",
-                "reference": "80cdd62e56c7bf54d35ea2f012786e6cf7d4de27",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/8c3209a00e424f1ddcdfff15cb80081373210681",
+                "reference": "8c3209a00e424f1ddcdfff15cb80081373210681",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable28"
             },
-            "time": "2024-04-06T00:32:02+00:00"
+            "time": "2024-05-09T00:34:08+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency