### PR TITLE
fix: properly check part file sizes on upload

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -103,10 +103,6 @@ class Operation implements IComplexOperation, ISpecificOperation {
 			return false;
 		}
 
-		if (preg_match('/\.ocTransferId\d+\.part$/i', $path)) {
-			return false;
-		}
-
 		// '', admin, 'files', 'path/to/file.txt'
 		$segment = explode('/', $fullPath, 4);
 
@@ -116,6 +112,7 @@ class Operation implements IComplexOperation, ISpecificOperation {
 		}
 
 		return isset($segment[2]) && in_array($segment[2], [
+			'uploads',
 			'files',
 			'thumbnails',
 			'files_versions',


### PR DESCRIPTION
Fix #580 

This is partially reverting #330. Not sure about this one because of potential side effects.

About scanning part files:
> Their name is not the final, the size is wrong, tags are missing, etc.