### PR TITLE
fix: ignore root mount when getting mount for node

### DIFF
--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -274,8 +274,16 @@ class Operation implements IComplexOperation, ISpecificOperation {
 	 * @param array|ICacheEntry|null $cacheEntry
 	 */
 	private function getNode(IStorage $storage, string $path, $cacheEntry = null): ?Node {
-		/** @var IMountPoint|false $mountPoint */
-		$mountPoint = current($this->mountManager->findByStorageId($storage->getId()));
+		$mountPoint = null;
+		$mounts = $this->mountManager->findByStorageId($storage->getId());
+		foreach ($mounts as $mount) {
+			// we don't want to root mount;
+			if (strlen($mount->getMountPoint()) > 2) {
+				$mountPoint = $mount;
+				break;
+			}
+		}
+
 		if (!$mountPoint) {
 			return null;
 		}


### PR DESCRIPTION
This is made redundant by https://github.com/nextcloud/files_accesscontrol/pull/757 but this might be easier to backport so I'm submitting both of them