### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "cd912d2ba9fca6027ee4d0a55fd06c41c75af4d2"
+                "reference": "50fef0ff2189206a5228b81044f1730c2aa4b396"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/cd912d2ba9fca6027ee4d0a55fd06c41c75af4d2",
-                "reference": "cd912d2ba9fca6027ee4d0a55fd06c41c75af4d2",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/50fef0ff2189206a5228b81044f1730c2aa4b396",
+                "reference": "50fef0ff2189206a5228b81044f1730c2aa4b396",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/master"
             },
-            "time": "2026-03-27T01:17:33+00:00"
+            "time": "2026-03-31T01:18:57+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency