### PR TITLE
[stable33] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5"
+                "reference": "338330faa9ce0c50117257614ede27034d527a31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f5a898fb7795fa28a135f528105b8628df6d97f5",
-                "reference": "f5a898fb7795fa28a135f528105b8628df6d97f5",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/338330faa9ce0c50117257614ede27034d527a31",
+                "reference": "338330faa9ce0c50117257614ede27034d527a31",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable33"
             },
-            "time": "2026-03-27T01:17:36+00:00"
+            "time": "2026-04-17T01:25:07+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency