### PR TITLE
Add support for granular permissions in operation

### DIFF
--- a/lib/CacheWrapper.php
+++ b/lib/CacheWrapper.php
@@ -45,7 +45,10 @@ class CacheWrapper extends Wrapper {
 					$jailedPath = $storage->getJailedPath($path);
 					$path = $jailedPath ?? $path;
 				}
-				$this->operation->checkFileAccess($path, $this->mountPoint, $entry['mimetype'] === 'httpd/unix-directory', $entry);
+				$permissions = $this->operation->checkFileAccess($path, $this->mountPoint, $entry['mimetype'] === 'httpd/unix-directory', $entry, 0);
+				if ($permissions !== null) {
+					$entry['permissions'] &= $permissions;
+				}
 			} catch (ForbiddenException) {
 				$entry['permissions'] &= $this->mask;
 			}

--- a/lib/Operation.php
+++ b/lib/Operation.php
@@ -14,6 +14,7 @@ use OC\Files\Node\Folder;
 use OC\Files\View;
 use OCA\GroupFolders\Mount\GroupMountPoint;
 use OCA\WorkflowEngine\Entity\File;
+use OCP\Constants;
 use OCP\EventDispatcher\Event;
 use OCP\Files\Cache\ICacheEntry;
 use OCP\Files\ForbiddenException;
@@ -46,19 +47,29 @@ class Operation implements IComplexOperation, ISpecificOperation {
 	}
 
 	/**
+	 * Checks if the user can access the file according to the configured flows.
+	 *
+	 * Flows with `deny` operation always take precedence and make the check fail.
+	 *
+	 * If only flows with permissions match, requiredPermissions is used to decide
+	 * when the check should fail or succeed. If its value is 0, the function simply
+	 * returns the permissions granted by the flows.
+	 *
 	 * @param array|ICacheEntry|null $cacheEntry
+	 * @param int $requiredPermissions Permissions required for the check
+	 * @return int|null If access is not blocked, the permissions allowed by the operations or null if not relevant.
 	 * @throws ForbiddenException
 	 */
-	public function checkFileAccess(string $path, IMountPoint $mountPoint, bool $isDir, $cacheEntry = null): void {
+	public function checkFileAccess(string $path, IMountPoint $mountPoint, bool $isDir, $cacheEntry = null, int $requiredPermissions = Constants::PERMISSION_ALL): ?int {
 		if (!$this->isBlockablePath($mountPoint, $path) || $this->isCreatingSkeletonFiles() || $this->nestingLevel !== 0) {
 			// Allow creating skeletons and theming
 			// https://github.com/nextcloud/files_accesscontrol/issues/5
 			// https://github.com/nextcloud/files_accesscontrol/issues/12
-			return;
+			return null;
 		}
 		$storage = $mountPoint->getStorage();
 		if ($storage === null) {
-			return;
+			return null;
 		}
 
 		$this->nestingLevel++;
@@ -71,16 +82,43 @@ class Operation implements IComplexOperation, ISpecificOperation {
 			$ruleMatcher->setEntitySubject($this->fileEntity, $node);
 		}
 		$ruleMatcher->setOperation($this);
-		$match = $ruleMatcher->getFlows();
+		$match = $ruleMatcher->getFlows(false);
 
 		$this->nestingLevel--;
 
 		if (!empty($match)) {
+			$isDenied = false;
+			$computedPermissions = 0;
+			foreach ($match as $operation) {
+				$operationString = $operation['operation'];
+				if ($operationString === 'deny') {
+					$isDenied = true;
+					// block file access as if a deny operation is present it should take precedence
+					break;
+				}
+
+				try {
+					$parsedOperationParams = json_decode($operationString, true, flags: JSON_THROW_ON_ERROR);
+				} catch (\JsonException) {
+					// if we can't decode as JSON ignore...
+					continue;
+				}
+
+				$computedPermissions |= (int)($parsedOperationParams['permissions'] ?? 0);
+			}
+
+			if (!$isDenied && ($computedPermissions & $requiredPermissions) === $requiredPermissions) {
+				// enough permissions to perform the operation
+				return $computedPermissions;
+			}
+
 			$e = new \RuntimeException('Access denied for path ' . $path . ' that is ' . ($isDir ? '' : 'not ') . 'a directory and matches rules: ' . (string)json_encode($match));
 			$this->logger->debug($e->getMessage(), ['exception' => $e]);
 			// All Checks of one operation matched: prevent access
 			throw new ForbiddenException('Access denied by access control', false);
 		}
+
+		return null;
 	}
 
 	protected function isBlockablePath(IMountPoint $mountPoint, string $path): bool {

--- a/lib/StorageWrapper.php
+++ b/lib/StorageWrapper.php
@@ -40,10 +40,11 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	}
 
 	/**
+	 * @see Operation::checkFileAccess()
 	 * @throws ForbiddenException
 	 */
-	protected function checkFileAccess(string $path, ?bool $isDir = null): void {
-		$this->operation->checkFileAccess($path, $this->mount, is_bool($isDir) ? $isDir : $this->is_dir($path));
+	protected function checkFileAccess(string $path, ?bool $isDir = null, ?int $permissions = null): ?int {
+		return $this->operation->checkFileAccess($path, $this->mount, is_bool($isDir) ? $isDir : $this->is_dir($path), null, $permissions ?? Constants::PERMISSION_ALL);
 	}
 
 	/*
@@ -59,7 +60,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function mkdir($path): bool {
-		$this->checkFileAccess($path, true);
+		$this->checkFileAccess($path, true, Constants::PERMISSION_CREATE);
 		return $this->storage->mkdir($path);
 	}
 
@@ -72,7 +73,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function rmdir($path): bool {
-		$this->checkFileAccess($path, true);
+		$this->checkFileAccess($path, true, Constants::PERMISSION_DELETE);
 		return $this->storage->rmdir($path);
 	}
 
@@ -85,7 +86,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function isCreatable($path): bool {
 		try {
-			$this->checkFileAccess($path);
+			$this->checkFileAccess($path, null, Constants::PERMISSION_CREATE);
 		} catch (ForbiddenException) {
 			return false;
 		}
@@ -101,7 +102,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function isReadable($path): bool {
 		try {
-			$this->checkFileAccess($path);
+			$this->checkFileAccess($path, null, Constants::PERMISSION_READ);
 		} catch (ForbiddenException) {
 			return false;
 		}
@@ -117,7 +118,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function isUpdatable($path): bool {
 		try {
-			$this->checkFileAccess($path);
+			$this->checkFileAccess($path, null, Constants::PERMISSION_UPDATE);
 		} catch (ForbiddenException) {
 			return false;
 		}
@@ -133,7 +134,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function isDeletable($path): bool {
 		try {
-			$this->checkFileAccess($path);
+			$this->checkFileAccess($path, null, Constants::PERMISSION_DELETE);
 		} catch (ForbiddenException) {
 			return false;
 		}
@@ -143,10 +144,16 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function getPermissions($path): int {
 		try {
-			$this->checkFileAccess($path);
+			$permissions = $this->checkFileAccess($path, null, 0);
 		} catch (ForbiddenException) {
 			return $this->mask;
 		}
+
+		if ($permissions !== null) {
+			// override with permissions granted by the operation, if any
+			return $permissions & $this->storage->getPermissions($path);
+		}
+
 		return $this->storage->getPermissions($path);
 	}
 
@@ -159,7 +166,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function file_get_contents($path): string|false {
-		$this->checkFileAccess($path, false);
+		$this->checkFileAccess($path, false, Constants::PERMISSION_READ);
 		return $this->storage->file_get_contents($path);
 	}
 
@@ -173,7 +180,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function file_put_contents(string $path, mixed $data): int|float|false {
-		$this->checkFileAccess($path, false);
+		$this->checkFileAccess($path, false, Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE);
 		return $this->storage->file_put_contents($path, $data);
 	}
 
@@ -186,7 +193,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function unlink($path): bool {
-		$this->checkFileAccess($path, false);
+		$this->checkFileAccess($path, false, Constants::PERMISSION_DELETE);
 		return $this->storage->unlink($path);
 	}
 
@@ -201,8 +208,8 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function rename($source, $target): bool {
 		$isDir = $this->is_dir($source);
-		$this->checkFileAccess($source, $isDir);
-		$this->checkFileAccess($target, $isDir);
+		$this->checkFileAccess($source, $isDir, Constants::PERMISSION_READ | Constants::PERMISSION_DELETE);
+		$this->checkFileAccess($target, $isDir, Constants::PERMISSION_CREATE);
 		return $this->storage->rename($source, $target);
 	}
 
@@ -217,8 +224,8 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function copy($source, $target): bool {
 		$isDir = $this->is_dir($source);
-		$this->checkFileAccess($source, $isDir);
-		$this->checkFileAccess($target, $isDir);
+		$this->checkFileAccess($source, $isDir, Constants::PERMISSION_READ);
+		$this->checkFileAccess($target, $isDir, Constants::PERMISSION_CREATE);
 		return $this->storage->copy($source, $target);
 	}
 
@@ -232,7 +239,18 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function fopen($path, $mode) {
-		$this->checkFileAccess($path, false);
+		$hasPlus = str_contains($mode, '+');
+		$isRead = str_contains($mode, 'r');
+		$isExclusive = str_contains($mode, 'x');
+		$isWac = str_contains($mode, 'w') || str_contains($mode, 'a') || str_contains($mode, 'c');
+		$checkPermissions = match (true) {
+			$isWac => Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | ($hasPlus ? Constants::PERMISSION_READ : 0),
+			$isExclusive => Constants::PERMISSION_CREATE | ($hasPlus ? Constants::PERMISSION_READ : 0),
+			$isRead => Constants::PERMISSION_READ | ($hasPlus ? Constants::PERMISSION_UPDATE : 0),
+			default => Constants::PERMISSION_ALL,
+		};
+
+		$this->checkFileAccess($path, false, $checkPermissions);
 		return $this->storage->fopen($path, $mode);
 	}
 
@@ -247,7 +265,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function touch($path, $mtime = null): bool {
-		$this->checkFileAccess($path, false);
+		$this->checkFileAccess($path, false, Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE);
 		return $this->storage->touch($path, $mtime);
 	}
 
@@ -278,7 +296,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	 */
 	#[\Override]
 	public function getDirectDownload($path): array|false {
-		$this->checkFileAccess($path, false);
+		$this->checkFileAccess($path, false, Constants::PERMISSION_READ);
 		return $this->storage->getDirectDownload($path);
 	}
 
@@ -302,7 +320,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 		// We would have actually a result, so lets see if the user should be able to access it
 		$path = $this->getCache()->getPathById((int)$fileId);
 		if ($path !== null) {
-			$this->checkFileAccess($path, false);
+			$this->checkFileAccess($path, false, Constants::PERMISSION_READ);
 		}
 
 		return $data;
@@ -321,7 +339,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 			return $this->copy($sourceInternalPath, $targetInternalPath);
 		}
 
-		$this->checkFileAccess($targetInternalPath, $sourceStorage->is_dir($sourceInternalPath));
+		$this->checkFileAccess($targetInternalPath, $sourceStorage->is_dir($sourceInternalPath), Constants::PERMISSION_CREATE);
 		return $this->storage->copyFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
@@ -338,7 +356,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 			return $this->rename($sourceInternalPath, $targetInternalPath);
 		}
 
-		$this->checkFileAccess($targetInternalPath, $sourceStorage->is_dir($sourceInternalPath));
+		$this->checkFileAccess($targetInternalPath, $sourceStorage->is_dir($sourceInternalPath), Constants::PERMISSION_CREATE);
 		return $this->storage->moveFromStorage($sourceStorage, $sourceInternalPath, $targetInternalPath);
 	}
 
@@ -348,7 +366,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 	#[\Override]
 	public function writeStream(string $path, $stream, ?int $size = null): int {
 		if (!$this->isPartFile($path)) {
-			$this->checkFileAccess($path, false);
+			$this->checkFileAccess($path, false, Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE);
 		}
 
 		$result = parent::writeStream($path, $stream, $size);
@@ -359,7 +377,7 @@ class StorageWrapper extends Wrapper implements IWriteStreamStorage {
 		// Required for object storage since part file is not in the storage so we cannot check it before moving it to the storage
 		// As an alternative we might be able to check on the cache update/insert/delete though the Cache wrapper
 		try {
-			$this->checkFileAccess($path, false);
+			$this->checkFileAccess($path, false, Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE);
 		} catch (\Exception $e) {
 			$this->storage->unlink($path);
 			throw $e;

--- a/tests/Integration/features/author.feature
+++ b/tests/Integration/features/author.feature
@@ -16,6 +16,21 @@ Feature: Author
     Then The webdav response should have a status code "403"
     Then User "test1" sees no files in the trashbin
 
+  Scenario: Propfind has restrictive permissions when file is blocked
+    Given User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
+    And The webdav response should have a status code "201"
+    And user "admin" creates global flow with 200
+      | name      | Admin flow                       |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | deny                             |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName","operator":"is","value":"foobar.txt"} |
+    And as user "test1"
+    When File "foobar.txt" in listing of folder "/" should have prop "oc:permissions" equal to "R"
+    When Downloading file "/foobar.txt"
+    Then The webdav response should have a status code "404"
+
   Scenario: Downloading file is blocked
     Given User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
     And The webdav response should have a status code "201"

--- a/tests/Integration/features/bootstrap/WebDav.php
+++ b/tests/Integration/features/bootstrap/WebDav.php
@@ -191,6 +191,37 @@ trait WebDav {
 	}
 
 	/**
+	 * @Then /^File "([^"]*)" in listing of folder "([^"]*)" should have prop "([^"]*):([^"]*)" equal to "([^"]*)"$/
+	 */
+	public function checkPropForFileInFolder($file, $folder, $prefix, $prop, $value): void {
+		$mappedNs = match ($prefix) {
+			'oc' => '{http://owncloud.org/ns}',
+			'nc' => '{http://nextcloud.org/ns}',
+			'd' => '{DAV:}',
+			's' => '{http://sabredav.org/ns}',
+			default => throw new \UnexpectedValueException("Unknown prefix: $prefix")
+		};
+
+		$propKey = "$mappedNs$prop";
+		$response = $this->listFolder($this->currentUser, $folder, 1, [$propKey]);
+
+		$folder = trim($folder, '/');
+		$file = trim($file, '/');
+		$filePath = str_replace('//', '/', "/$folder/$file");
+		$key = '/' . $this->getDavFilesPath($this->currentUser) . $filePath;
+		if (!array_key_exists($key, $response)) {
+			Assert::fail("File $file is not in folder $folder");
+		}
+
+		if (!array_key_exists($propKey, $response[$key])) {
+			Assert::fail("Property $propKey not found in file $file");
+		}
+
+		$property = $response[$key][$propKey];
+		Assert::assertEquals($value, $property);
+	}
+
+	/**
 	 * @Then /^File "([^"]*)" should have prop "([^"]*):([^"]*)" equal to "([^"]*)"$/
 	 * @param string $file
 	 * @param string $prefix

--- a/tests/Integration/features/permissions.feature
+++ b/tests/Integration/features/permissions.feature
@@ -1,0 +1,105 @@
+Feature: Author
+  Background:
+    Given user "test1" exists
+    Given as user "test1"
+    And using new dav path
+
+  Scenario: with UPDATE permissions blocks upload
+    Given user "admin" creates global flow with 200
+      | name      | Flow with UPDATE permissions     |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 2}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    And User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
+    Then The webdav response should have a status code "403"
+    Then User "test1" sees no files in the trashbin
+
+  Scenario: without UPDATE blocks updating but allows uploading, reading and deleting
+    Given user "admin" creates global flow with 200
+      | name      | Flow with READ and UPDATE permissions |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 5}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    Given user "admin" creates global flow with 200
+      | name      | Flow with DELETE permissions     |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 8}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    And User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
+    Then The webdav response should have a status code "201"
+    And User "test1" uploads file "data/textfile-2.txt" to "/foobar.txt"
+    Then The webdav response should have a status code "403"
+    And User "test1" deletes file "/foobar.txt"
+    Then The webdav response should have a status code "204"
+    When User "test1" loads file list of trashbin
+    When as user "test1"
+    And Downloading first trashed file
+    Then The webdav response should have a status code "200"
+
+  Scenario: masked permissions are returned
+    Given user "admin" creates global flow with 200
+      | name      | Flow with READ and UPDATE permissions |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 5}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    Given user "admin" creates global flow with 200
+      | name      | Flow with DELETE permissions     |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 8}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    And User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
+    Then The webdav response should have a status code "201"
+    When as user "test1"
+    Then File "/foobar.txt" should have prop "oc:permissions" equal to "GDN"
+
+  Scenario: no permissions should block file
+    And User "test1" uploads file "data/textfile.txt" to "/foobar.txt"
+    Then The webdav response should have a status code "201"
+    When user "admin" creates global flow with 200
+      | name      | Flow with NONE permissions       |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 0}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    When as user "test1"
+    When File "foobar.txt" in listing of folder "/" should have prop "oc:permissions" equal to ""
+    When Downloading file "/foobar.txt"
+    Then The webdav response should have a status code "404"
+
+  Scenario: deny operation override permissions from other operations
+    Given User "test1" deletes folder "/dir"
+    Given User "test1" created a folder "/dir"
+    Then The webdav response should have a status code "201"
+    When User "test1" uploads file "data/textfile.txt" to "/dir/foobar.txt"
+    Then The webdav response should have a status code "201"
+    Given user "admin" creates global flow with 200
+      | name      | Flow with READ and UPDATE permissions |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | {"permissions": 5}               |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    Given user "admin" creates global flow with 200
+      | name      | Flow with DELETE permissions     |
+      | class     | OCA\FilesAccessControl\Operation |
+      | entity    | OCA\WorkflowEngine\Entity\File   |
+      | events    | []                               |
+      | operation | deny                             |
+      | checks-0  | {"class":"OCA\\\\WorkflowEngine\\\\Check\\\\FileName", "operator": "is", "value": "foobar.txt"} |
+    When as user "test1"
+    Then File "/dir/foobar.txt" should have prop "oc:permissions" equal to "R"
+    And user "test1" should see following elements
+      | /dir/foobar.txt  |
+    When Downloading file "/dir/foobar.txt"
+    Then The webdav response should have a status code "404"

--- a/tests/Unit/OperationTest.php
+++ b/tests/Unit/OperationTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\FilesAccessControl\Tests\Unit;
+
+use OCA\FilesAccessControl\Operation;
+use OCA\WorkflowEngine\Entity\File;
+use OCP\Constants;
+use OCP\Files\Cache\ICache;
+use OCP\Files\ForbiddenException;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountManager;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Storage\IStorage;
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\WorkflowEngine\IManager;
+use OCP\WorkflowEngine\IRuleMatcher;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class OperationTest extends TestCase {
+	private IManager&MockObject $manager;
+	private IRuleMatcher&MockObject $ruleMatcher;
+	private IMountPoint&MockObject $mountPoint;
+	private IStorage&MockObject $storage;
+	private Operation&MockObject $operation;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->manager = $this->createMock(IManager::class);
+		$this->ruleMatcher = $this->createMock(IRuleMatcher::class);
+		$this->storage = $this->createMock(IStorage::class);
+		$this->mountPoint = $this->createMock(IMountPoint::class);
+
+		$this->mountPoint->method('getMountPoint')->willReturn('/mount/');
+		$this->mountPoint->method('getStorage')->willReturn($this->storage);
+
+		// Make getNode() return null by having the cache return nothing
+		$cache = $this->createMock(ICache::class);
+		$cache->method('get')->willReturn(null);
+		$this->storage->method('getCache')->willReturn($cache);
+
+		$this->manager->method('getRuleMatcher')->willReturn($this->ruleMatcher);
+		$this->ruleMatcher->method('setFileInfo');
+		$this->ruleMatcher->method('setOperation');
+
+		$this->operation = $this->getMockBuilder(Operation::class)
+			->setConstructorArgs([
+				$this->manager,
+				$this->createMock(IL10N::class),
+				$this->createMock(IURLGenerator::class),
+				$this->createMock(File::class),
+				$this->createMock(IMountManager::class),
+				$this->createMock(IRootFolder::class),
+				$this->createMock(LoggerInterface::class),
+			])
+			->onlyMethods(['isBlockablePath', 'isCreatingSkeletonFiles', 'translatePath'])
+			->getMock();
+
+		$this->operation->method('isCreatingSkeletonFiles')->willReturn(false);
+		$this->operation->method('translatePath')->willReturn('path');
+	}
+
+	public function testCheckFileAccessWithNoMatchingFlowsReturnsNull(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([]);
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false);
+
+		$this->assertNull($result);
+	}
+
+	public function testCheckFileAccessWithNonBlockablePathReturnsNull(): void {
+		$this->operation->method('isBlockablePath')->willReturn(false);
+		$this->ruleMatcher->expects($this->never())->method('getFlows');
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false);
+
+		$this->assertNull($result);
+	}
+
+	public function testCheckFileAccessWithDenyOperationThrowsForbidden(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => 'deny'],
+		]);
+
+		$this->expectException(ForbiddenException::class);
+		$this->operation->checkFileAccess('path', $this->mountPoint, false);
+	}
+
+	public function testCheckFileAccessWithDenyOperationAfterGrantedPermissionsStillThrows(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_ALL])],
+			['operation' => 'deny'],
+		]);
+
+		$this->expectException(ForbiddenException::class);
+		$this->operation->checkFileAccess('path', $this->mountPoint, false, null, Constants::PERMISSION_READ);
+	}
+
+	public function testCheckFileAccessWithSufficientPermissionsReturnsComputedPermissions(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$grantedPermissions = Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE;
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => json_encode(['permissions' => $grantedPermissions])],
+		]);
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false, null, Constants::PERMISSION_READ);
+
+		$this->assertSame($grantedPermissions, $result);
+	}
+
+	public function testCheckFileAccessWithPermissionsAccumulatedAcrossRules(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_READ])],
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_UPDATE])],
+		]);
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false, null, Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE);
+
+		$this->assertSame(Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE, $result);
+	}
+
+	public function testCheckFileAccessWithInsufficientPermissionsThrowsForbidden(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_READ])],
+		]);
+
+		$this->expectException(ForbiddenException::class);
+		$this->operation->checkFileAccess('path', $this->mountPoint, false, null, Constants::PERMISSION_UPDATE);
+	}
+
+	public function testCheckFileAccessWithZeroRequiredPermissionsReturnsComputedPermissions(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_READ])],
+		]);
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false, null, 0);
+
+		$this->assertSame(Constants::PERMISSION_READ, $result);
+	}
+
+	public function testCheckFileAccessWithInvalidJsonOperationIsIgnored(): void {
+		$this->operation->method('isBlockablePath')->willReturn(true);
+		$this->ruleMatcher->method('getFlows')->willReturn([
+			['operation' => 'not-valid-json'],
+			['operation' => json_encode(['permissions' => Constants::PERMISSION_READ])],
+		]);
+
+		$result = $this->operation->checkFileAccess('path', $this->mountPoint, false, null, Constants::PERMISSION_READ);
+
+		$this->assertSame(Constants::PERMISSION_READ, $result);
+	}
+}

--- a/tests/Unit/StorageWrapperTest.php
+++ b/tests/Unit/StorageWrapperTest.php
@@ -11,8 +11,10 @@ namespace OCA\FilesAccessControl\Tests\Unit;
 use OC\Files\Storage\Storage;
 use OCA\FilesAccessControl\Operation;
 use OCA\FilesAccessControl\StorageWrapper;
+use OCP\Constants;
 use OCP\Files\ForbiddenException;
 use OCP\Files\Mount\IMountPoint;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use Test\TestCase;
 
@@ -57,9 +59,7 @@ class StorageWrapperTest extends TestCase {
 		];
 	}
 
-	/**
-	 * @dataProvider dataCheckFileAccess
-	 */
+	#[DataProvider('dataCheckFileAccess')]
 	public function testCheckFileAccess(string $path, bool $isDir): void {
 		$storage = $this->getInstance();
 
@@ -68,6 +68,16 @@ class StorageWrapperTest extends TestCase {
 			->with($path, $this->mountPoint, $isDir);
 
 		self::invokePrivate($storage, 'checkFileAccess', [$path, $isDir]);
+	}
+
+	public function testCheckFileAccessPassesPermissions(): void {
+		$storage = $this->getInstance();
+
+		$this->operation->expects($this->once())
+			->method('checkFileAccess')
+			->with('path', $this->mountPoint, false, null, Constants::PERMISSION_READ);
+
+		self::invokePrivate($storage, 'checkFileAccess', ['path', false, Constants::PERMISSION_READ]);
 	}
 
 	public static function dataSinglePath(): array {
@@ -85,9 +95,7 @@ class StorageWrapperTest extends TestCase {
 		return $tests;
 	}
 
-	/**
-	 * @dataProvider dataSinglePath
-	 */
+	#[DataProvider('dataSinglePath')]
 	public function testSinglePath(string $method, string $path, bool $return, ?\Exception $expected): void {
 		$storage = $this->getInstance(['checkFileAccess']);
 
@@ -136,9 +144,71 @@ class StorageWrapperTest extends TestCase {
 		return $tests;
 	}
 
-	/**
-	 * @dataProvider dataSinglePathOverWritten
-	 */
+	public static function dataGetPermissions(): array {
+		return [
+			// operation returns null (no rule matched) → unmodified storage permissions
+			[null, null, Constants::PERMISSION_ALL, Constants::PERMISSION_ALL],
+			// operation returns granted permissions → intersected with storage
+			[Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE, null, Constants::PERMISSION_ALL, Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE],
+			// operation grants more than storage has → storage wins
+			[Constants::PERMISSION_ALL, null, Constants::PERMISSION_READ, Constants::PERMISSION_READ],
+			// operation throws ForbiddenException → mask (PERMISSION_SHARE only)
+			[null, new ForbiddenException('denied', false), Constants::PERMISSION_ALL, Constants::PERMISSION_SHARE],
+		];
+	}
+
+	#[DataProvider('dataGetPermissions')]
+	public function testGetPermissions(?int $operationReturn, ?\Exception $operationException, int $storagePermissions, int $expected): void {
+		$storageWrapper = $this->getInstance(['checkFileAccess']);
+
+		if ($operationException !== null) {
+			$storageWrapper->method('checkFileAccess')->willThrowException($operationException);
+		} else {
+			$storageWrapper->method('checkFileAccess')->willReturn($operationReturn);
+		}
+
+		$this->storage->method('getPermissions')->willReturn($storagePermissions);
+
+		$this->assertSame($expected, $storageWrapper->getPermissions('path'));
+	}
+
+	public static function dataFopenModes(): array {
+		$rw = Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE;
+		$cw = Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE;
+		$crw = Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_READ;
+		return [
+			['r',   Constants::PERMISSION_READ],
+			['rb',  Constants::PERMISSION_READ],
+			['r+',  $rw],
+			['r+b', $rw],
+			['rb+', $rw],
+			['w',   $cw],
+			['wb',  $cw],
+			['w+',  $crw],
+			['a',   $cw],
+			['a+',  $crw],
+			['c',   $cw],
+			['c+',  $crw],
+			['x',   Constants::PERMISSION_CREATE],
+			['x+',  Constants::PERMISSION_CREATE | Constants::PERMISSION_READ],
+			['+zpZ', Constants::PERMISSION_ALL], // invalid mode → safe default
+		];
+	}
+
+	#[DataProvider('dataFopenModes')]
+	public function testFopenPermissionMapping(string $mode, int $expectedPermissions): void {
+		$storageWrapper = $this->getInstance(['checkFileAccess']);
+
+		$storageWrapper->expects($this->once())
+			->method('checkFileAccess')
+			->with('path', false, $expectedPermissions);
+
+		$this->storage->method('fopen')->willReturn(false);
+
+		$storageWrapper->fopen('path', $mode);
+	}
+
+	#[DataProvider('dataSinglePathOverWritten')]
 	public function testSinglePathOverWritten(string $method, string $path, bool $return, ?\Exception $checkAccess, bool $expected): void {
 		$storage = $this->getInstance(['checkFileAccess']);
 


### PR DESCRIPTION
### Description

Adds partial* support for granular permissions in `Operation` keeping the current behaviour intact.

**\* refers to the fact that additional work is required to support this in the UI. The current use-case is for WFE Runtime Operations, which are not stored in the DB and not shown in the UI.**

### Implementation details

Currently the `operation` field of the operation is always set to `deny`. This PR adds a json object of the shape `{ "permissions": int }` to allow the definition of a custom set of permissions for the operation.

The `StorageWrapper` then checks against those permissions to see if the action is to be denied or not and returns the masked permissions when appropriate. 

**Note:** AI has been used to review the code and concept and to fix some issues with the original code.

## TODO

- [x] Add integration tests