### PR TITLE
[stable34] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "72de02fbad95545055983d050e564fe39128992d"
+                "reference": "adf732a4b3e97086e8fbaf6ddb02880d99613151"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/72de02fbad95545055983d050e564fe39128992d",
-                "reference": "72de02fbad95545055983d050e564fe39128992d",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/adf732a4b3e97086e8fbaf6ddb02880d99613151",
+                "reference": "adf732a4b3e97086e8fbaf6ddb02880d99613151",
                 "shasum": ""
             },
             "require": {
@@ -54,7 +54,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable34"
             },
-            "time": "2026-05-15T08:43:27+00:00"
+            "time": "2026-05-30T01:59:40+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency