### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/vendor-bin/nextcloud-ocp/composer.lock
+++ b/vendor-bin/nextcloud-ocp/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "ef43111aa5096fc2818ff79631cd0801ec4e3cc4"
+                "reference": "39036e6ed88eee927c4b3e7ba7c5544b131e9439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/ef43111aa5096fc2818ff79631cd0801ec4e3cc4",
-                "reference": "ef43111aa5096fc2818ff79631cd0801ec4e3cc4",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/39036e6ed88eee927c4b3e7ba7c5544b131e9439",
+                "reference": "39036e6ed88eee927c4b3e7ba7c5544b131e9439",
                 "shasum": ""
             },
             "require": {
@@ -53,7 +53,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-06-03T02:42:41+00:00"
+            "time": "2026-06-12T02:30:15+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency